### PR TITLE
fix: add service account to cloud run deployments

### DIFF
--- a/.github/workflows/deploy-aegis.yaml
+++ b/.github/workflows/deploy-aegis.yaml
@@ -40,6 +40,7 @@ jobs:
             --source ./deploy_source/aegis \
             --region ${{ secrets.GCP_REGION }} \
             --allow-unauthenticated \
+            --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }} \
             --set-build-env-vars=BP_PYTHON_VERSION=3.11.9 \
             --set-env-vars=ALLOWED_ORIGIN=${{ secrets.ALLOWED_ORIGIN }},YOUR_EMAIL=${{ secrets.YOUR_EMAIL }} \
             --set-secrets=SENDGRID_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/SENDGRID_API_KEY:latest,BACKNINE_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/BACKNINE_API_KEY:latest \

--- a/.github/workflows/deploy-architect.yaml
+++ b/.github/workflows/deploy-architect.yaml
@@ -39,6 +39,7 @@ jobs:
             --source ./deploy_source/architect \
             --region ${{ secrets.GCP_REGION }} \
             --allow-unauthenticated \
+            --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }} \
             --set-build-env-vars=BP_PYTHON_VERSION=3.11.9 \
             --set-env-vars=ALLOWED_ORIGIN=${{ secrets.ALLOWED_ORIGIN }},YOUR_EMAIL=${{ secrets.YOUR_EMAIL }},GITHUB_REPOSITORY=${{ github.repository }} \
             --set-secrets=SENDGRID_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/SENDGRID_API_KEY:latest,GITHUB_TOKEN=projects/${{ secrets.GCP_PROJECT }}/secrets/GH_TOKEN:latest \

--- a/.github/workflows/deploy-growth.yaml
+++ b/.github/workflows/deploy-growth.yaml
@@ -39,6 +39,7 @@ jobs:
             --source ./deploy_source/growth \
             --region ${{ secrets.GCP_REGION }} \
             --allow-unauthenticated \
+            --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }} \
             --set-build-env-vars=BP_PYTHON_VERSION=3.11.9 \
             --set-env-vars=ALLOWED_ORIGIN=${{ secrets.ALLOWED_ORIGIN }},GCS_BUCKET_NAME=${{ secrets.GCS_BUCKET_NAME }},GCS_UPLOAD_PREFIX=${{ secrets.GCS_UPLOAD_PREFIX }},GROWTH_AGENT_TEMPLATE_ID=${{ secrets.GROWTH_AGENT_TEMPLATE_ID }},YOUR_EMAIL=${{ secrets.YOUR_EMAIL }},GUNICORN_CMD_ARGS="--timeout 120 --graceful-timeout 120 --workers 1 --threads 8" \
             --set-secrets=SENDGRID_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/SENDGRID_API_KEY:latest \

--- a/.github/workflows/deploy-insurance-sales-agent.yaml
+++ b/.github/workflows/deploy-insurance-sales-agent.yaml
@@ -33,6 +33,7 @@ jobs:
             --source ./agents/insurance_sales_agent/backend \
             --region ${{ secrets.GCP_REGION }} \
             --allow-unauthenticated \
+            --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }} \
             --set-env-vars=ETHOS_URL=${{ secrets.ETHOS_URL }},BACKNINE_URL=${{ secrets.BACKNINE_URL }},EMAIL_RECEIVE=${{ secrets.EMAIL_RECEIVE }},AI_MODEL=${{ secrets.AI_MODEL }},OLLAMA_HOST=${{ secrets.OLLAMA_HOST }} \
             --set-secrets=OPENAI_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/OPENAI_API_KEY:latest,SENDGRID_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/SENDGRID_API_KEY:latest \
             --memory=1Gi

--- a/.github/workflows/deploy-oracle.yaml
+++ b/.github/workflows/deploy-oracle.yaml
@@ -39,6 +39,7 @@ jobs:
             --source ./deploy_source/oracle \
             --region ${{ secrets.GCP_REGION }} \
             --allow-unauthenticated \
+            --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }} \
             --set-build-env-vars=BP_PYTHON_VERSION=3.11.9 \
             --set-env-vars=ALLOWED_ORIGIN=${{ secrets.ALLOWED_ORIGIN }},GCS_BUCKET_NAME=${{ secrets.GCS_BUCKET_NAME }},GCS_UPLOAD_PREFIX=${{ secrets.GCS_UPLOAD_PREFIX }},AUDIT_TEMPLATE_ID=${{ secrets.AUDIT_TEMPLATE_ID }},YOUR_EMAIL=${{ secrets.YOUR_EMAIL }},GUNICORN_CMD_ARGS="--timeout 120 --graceful-timeout 120 --workers 1 --threads 8" \
             --set-secrets=SENDGRID_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/SENDGRID_API_KEY:latest \


### PR DESCRIPTION
The agent deployments were failing after the initial fix because the Cloud Run services were running with a default service account that lacked the necessary IAM permissions.

This commit adds the `--service-account` flag to the `gcloud run deploy` command in the workflow files for all five agents. This ensures that the running services are authenticated correctly and have the required permissions to operate.