### PR TITLE
fix: quote --set-env-vars value in deployment workflow

### DIFF
--- a/.github/workflows/deploy-insurance-sales-agent.yaml
+++ b/.github/workflows/deploy-insurance-sales-agent.yaml
@@ -34,6 +34,6 @@ jobs:
             --region ${{ secrets.GCP_REGION }} \
             --allow-unauthenticated \
             --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }} \
-            --set-env-vars=ETHOS_URL=${{ secrets.ETHOS_URL }},BACKNINE_URL=${{ secrets.BACKNINE_URL }},EMAIL_RECEIVE=${{ secrets.EMAIL_RECEIVE }},AI_MODEL=${{ secrets.AI_MODEL }},OLLAMA_HOST=${{ secrets.OLLAMA_HOST }} \
+            --set-env-vars="ETHOS_URL=${{ secrets.ETHOS_URL }},BACKNINE_URL=${{ secrets.BACKNINE_URL }},EMAIL_RECEIVE=${{ secrets.EMAIL_RECEIVE }},AI_MODEL=${{ secrets.AI_MODEL }},OLLAMA_HOST=${{ secrets.OLLAMA_HOST }}" \
             --set-secrets=OPENAI_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/OPENAI_API_KEY:latest,SENDGRID_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/SENDGRID_API_KEY:latest \
             --memory=1Gi


### PR DESCRIPTION
The deployment for the `insurance-sales-agent` was failing with a command-line parsing error because the `--set-env-vars` flag was not quoted. If a secret value contained a space, the shell would interpret it as multiple arguments, causing the `gcloud` command to fail.

This commit wraps the entire value of the `--set-env-vars` flag in double quotes to ensure it is treated as a single argument, resolving the parsing error.