### PR TITLE
fix: use custom delimiter for --set-env-vars

### DIFF
--- a/.github/workflows/deploy-insurance-sales-agent.yaml
+++ b/.github/workflows/deploy-insurance-sales-agent.yaml
@@ -34,6 +34,7 @@ jobs:
             --region ${{ secrets.GCP_REGION }} \
             --allow-unauthenticated \
             --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }} \
-            --set-env-vars="ETHOS_URL=${{ secrets.ETHOS_URL }},BACKNINE_URL=${{ secrets.BACKNINE_URL }},EMAIL_RECEIVE=${{ secrets.EMAIL_RECEIVE }},AI_MODEL=${{ secrets.AI_MODEL }},OLLAMA_HOST=${{ secrets.OLLAMA_HOST }}" \
+            --env-vars-delimiter="^:^" \
+            --set-env-vars="ETHOS_URL=${{ secrets.ETHOS_URL }}^:^BACKNINE_URL=${{ secrets.BACKNINE_URL }}^:^EMAIL_RECEIVE=${{ secrets.EMAIL_RECEIVE }}^:^AI_MODEL=${{ secrets.AI_MODEL }}^:^OLLAMA_HOST=${{ secrets.OLLAMA_HOST }}" \
             --set-secrets=OPENAI_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/OPENAI_API_KEY:latest,SENDGRID_API_KEY=projects/${{ secrets.GCP_PROJECT }}/secrets/SENDGRID_API_KEY:latest \
             --memory=1Gi


### PR DESCRIPTION
The deployment for the `insurance-sales-agent` was failing with a command-line parsing error. This was happening because the default comma delimiter for `--set-env-vars` can cause issues if secret values contain special characters.

This commit updates the command to use the `^:^` delimiter, as recommended by the gcloud documentation for robustly handling environment variables.