### PR TITLE
chore: add debug step to list files in workflow

### DIFF
--- a/.github/workflows/deploy-insurance-sales-agent.yaml
+++ b/.github/workflows/deploy-insurance-sales-agent.yaml
@@ -40,6 +40,9 @@ jobs:
           OLLAMA_HOST: "${{ secrets.OLLAMA_HOST }}"
           EOF
 
+      - name: List files for debugging
+        run: ls -lR ./deploy_source
+
       - name: Deploy to Cloud Run (source)
         run: |
           gcloud run deploy insurance-sales-agent \


### PR DESCRIPTION
A `ls -lR` command has been added to the `insurance-sales-agent` deployment workflow to help diagnose a "file not found" error. This will provide visibility into the runner's file system state before the deployment command runs.